### PR TITLE
Ensure dependencies are present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,18 +710,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly as builder
+FROM tari-labs/rust:nightly as builder
 
 WORKDIR /opt/tarpaulin
 
@@ -18,10 +18,16 @@ RUN cd /opt/tarpaulin/ && \
     rm -rf /opt/tarpaulin/ && \
     rm -rf /usr/local/cargo/registry/
 
-FROM rustlang/rust:nightly
+FROM tari-labs/rust:nightly
 
 COPY --from=builder /usr/local/cargo/bin/cargo-tarpaulin /usr/local/cargo/bin/cargo-tarpaulin
 
 WORKDIR /volume
+
+RUN apt-get update && \
+    apt-get -y install cmake libc++-dev libc++abi-dev
+
+RUN rustup default nightly-2020-08-13-x86_64-unknown-linux-gnu && \
+rustup component add rustfmt --toolchain nightly-2020-08-13-x86_64-unknown-linux-gnu
 
 CMD cargo build && cargo tarpaulin


### PR DESCRIPTION
Instructions:

Initial:
```
docker system prune -a
```

Rust Image:
```
git clone https://github.com/tari-labs/docker.git
cd docker
cd rust
cd build
docker build -t tari-labs/rust:nightly -f Dockerfile .
```

Tarpaulin Image:
```
git clone https://github.com/StriderDM/tarpaulin.git
cd tarpaulin
git checkout tari_build
docker build -t xd009642/tarpaulin:develop-nightly -f Dockerfile-nightly .
```

To Run:
Note: Memory that docker can use will need to be increased substantially from the 2gb default.
```
cd tari
docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" -it --entrypoint /bin/bash xd009642/tarpaulin:develop-nightly

//once the container spins up, run the following in the interactive terminal
cargo build && cargo tarpaulin
```